### PR TITLE
Convert left over 5.4 closing bracket

### DIFF
--- a/scripts/input_registry.php
+++ b/scripts/input_registry.php
@@ -27,4 +27,4 @@ return array(
     'time'              => function () { return new Generic; },
     'url'               => function () { return new Generic; },
     'week'              => function () { return new Generic; },
-];
+);


### PR DESCRIPTION
Closing bracked of array was not converted to 5.3 style
