### PR TITLE
branch alias 2.1 for the service config has been changed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
             }
         },
         "branch-alias": {
-            "dev-develop-2": "2.0.x-dev"
+            "dev-develop-2": "2.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
As the change of service from `aura_html_helper` to `aura/html:helper` . 2.1 seems next release.
