### PR TITLE
Return empty string instead of null in AbstractList::__toString

### DIFF
--- a/src/Helper/AbstractList.php
+++ b/src/Helper/AbstractList.php
@@ -75,7 +75,7 @@ abstract class AbstractList extends AbstractHelper
         // if there is no stack of items, **do not** return an empty
         // <ul></ul> tag set.
         if (! $this->stack) {
-            return;
+            return '';
         }
 
         $tag = $this->getTag();

--- a/tests/unit/src/Helper/OlTest.php
+++ b/tests/unit/src/Helper/OlTest.php
@@ -26,7 +26,7 @@ class OlTest extends AbstractHelperTest
         $this->assertSame($expect, $actual);
 
         $actual = $ol()->__toString();
-        $expect = null;
+        $expect = '';
         $this->assertSame($expect, $actual);
     }
 
@@ -53,7 +53,7 @@ class OlTest extends AbstractHelperTest
         $this->assertSame($expect, $actual);
 
         $actual = $ol()->__toString();
-        $expect = null;
+        $expect = '';
         $this->assertSame($expect, $actual);
     }
 }

--- a/tests/unit/src/Helper/UlTest.php
+++ b/tests/unit/src/Helper/UlTest.php
@@ -26,7 +26,7 @@ class UlTest extends AbstractHelperTest
         $this->assertSame($expect, $actual);
 
         $actual = $ul()->__toString();
-        $expect = null;
+        $expect = '';
         $this->assertSame($expect, $actual);
     }
 
@@ -53,7 +53,7 @@ class UlTest extends AbstractHelperTest
         $this->assertSame($expect, $actual);
 
         $actual = $ul()->__toString();
-        $expect = null;
+        $expect = '';
         $this->assertSame($expect, $actual);
     }
 }


### PR DESCRIPTION
In PHP, `__toString` _must_ return a string, or an error is raised.
