### PR TITLE
Feature/better anchor helper

### DIFF
--- a/src/Helper/Anchor.php
+++ b/src/Helper/Anchor.php
@@ -25,7 +25,7 @@ class Anchor extends AbstractHelper
      *
      * @param string $href The anchor href specification.
      *
-     * @param string $text The text for the anchor.
+     * @param string $text The text for the anchor (optional. default: $href).
      *
      * @param array $attr Attributes for the anchor.
      *
@@ -34,8 +34,12 @@ class Anchor extends AbstractHelper
      * @return string
      *
      */
-    public function __invoke($href, $text, array $attr = array(), $escape = true)
+    public function __invoke($href, $text = null, array $attr = array(), $escape = true)
     {
+        if (null === $text) {
+            $text = $href;
+        }
+
         $base = array(
             'href' => $href,
         );

--- a/src/Helper/Anchor.php
+++ b/src/Helper/Anchor.php
@@ -29,10 +29,12 @@ class Anchor extends AbstractHelper
      *
      * @param array $attr Attributes for the anchor.
      *
+     * @param boolean $escape Set to false for raw text (default:true)
+     *
      * @return string
      *
      */
-    public function __invoke($href, $text, array $attr = array())
+    public function __invoke($href, $text, array $attr = array(), $escape = true)
     {
         $base = array(
             'href' => $href,
@@ -41,7 +43,11 @@ class Anchor extends AbstractHelper
         unset($attr['href']);
 
         $attr = $this->escaper->attr(array_merge($base, $attr));
-        $text = $this->escaper->html($text);
+
+        if ($escape) {
+            $text = $this->escaper->html($text);
+        }
+
         return "<a $attr>$text</a>";
     }
 }

--- a/tests/unit/src/Helper/AnchorTest.php
+++ b/tests/unit/src/Helper/AnchorTest.php
@@ -29,4 +29,19 @@ class AnchorTest extends AbstractHelperTest
         $expect = '<a href="/path/to/script.php" bar="baz">foo</a>';
         $this->assertSame($expect, $actual);
     }
+
+    public function testRawText()
+    {
+        $data = (object) array(
+            'href' => '/path/to/script.php',
+            'text' => '<span>HTML</span>',
+            'attribs' => [],
+            'escape' => false
+        );
+
+        $anchor = $this->helper;
+        $actual = $anchor($data->href, $data->text, $data->attribs, $data->escape);
+        $expect = '<a href="/path/to/script.php"><span>HTML</span></a>';
+        $this->assertSame($expect, $actual);
+    }
 }

--- a/tests/unit/src/Helper/AnchorTest.php
+++ b/tests/unit/src/Helper/AnchorTest.php
@@ -35,7 +35,7 @@ class AnchorTest extends AbstractHelperTest
         $data = (object) array(
             'href' => '/path/to/script.php',
             'text' => '<span>HTML</span>',
-            'attribs' => [],
+            'attribs' => array(),
             'escape' => false
         );
 

--- a/tests/unit/src/Helper/AnchorTest.php
+++ b/tests/unit/src/Helper/AnchorTest.php
@@ -44,4 +44,16 @@ class AnchorTest extends AbstractHelperTest
         $expect = '<a href="/path/to/script.php"><span>HTML</span></a>';
         $this->assertSame($expect, $actual);
     }
+
+    public function testHrefOnly()
+    {
+        $data = (object) array(
+            'href' => '/path/to/script.php',
+        );
+
+        $anchor = $this->helper;
+        $actual = $anchor($data->href);
+        $expect = '<a href="/path/to/script.php">/path/to/script.php</a>';
+        $this->assertSame($expect, $actual);
+    }
 }


### PR DESCRIPTION
This adds 2 pieces of functionality I would like to see in the Anchor helper.
- ability to use unescaped `$text`
- ability to only pass a `$href` and use `$href` for `$text` if `$text` is absent

The addition of the `$escape` param means I can create anchors which contain HTML.
Similar to the difference between `AbstractList::item()` and `AbstractList::rawItem()`.

The optional status of the `$text` param means I can more easily create anchors which simply display the href attribute as the text. I believe this to be a more accurate conception of the minimum information required to create an anchor element.

I probably should have split these into 2 pull request in retrospect. 
My apologies. 
Let me know if I should go back and do it that way.
