### PR TITLE
Add Helper/AnchorRaw for anchors w/ unescaped text

### DIFF
--- a/src/Helper/AnchorRaw.php
+++ b/src/Helper/AnchorRaw.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @package Aura.Html
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Html\Helper;
+
+/**
+ *
+ * Helper to generate `<a ... />` tags without escaping the $text param.
+ *
+ * @package Aura.Html
+ *
+ */
+class AnchorRaw extends AbstractHelper
+{
+    /**
+     *
+     * Returns an anchor tag with text left unescaped.
+     *
+     * @param string $href The anchor href specification.
+     *
+     * @param string $text The text for the anchor.
+     *
+     * @param array $attr Attributes for the anchor.
+     *
+     * @return string
+     *
+     */
+    public function __invoke($href, $text, array $attr = array())
+    {
+        $base = array(
+            'href' => $href,
+        );
+
+        unset($attr['href']);
+
+        $attr = $this->escaper->attr(array_merge($base, $attr));
+        return "<a $attr>$text</a>";
+    }
+}

--- a/src/HelperLocatorFactory.php
+++ b/src/HelperLocatorFactory.php
@@ -61,6 +61,8 @@ class HelperLocatorFactory
         return new HelperLocator(array(
             'a'                 => function () use ($escaper) { return new Helper\Anchor($escaper); },
             'anchor'            => function () use ($escaper) { return new Helper\Anchor($escaper); },
+            'aRaw'              => function () use ($escaper) { return new Helper\AnchorRaw($escaper); },
+            'anchorRaw'         => function () use ($escaper) { return new Helper\AnchorRaw($escaper); },
             'base'              => function () use ($escaper) { return new Helper\Base($escaper); },
             'escape'            => function () use ($escaper) { return $escaper; },
             'form'              => function () use ($escaper) { return new Helper\Form($escaper); },

--- a/tests/unit/src/Helper/AnchorRawTest.php
+++ b/tests/unit/src/Helper/AnchorRawTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Aura\Html\Helper;
+
+class AnchorRawTest extends AbstractHelperTest
+{
+    public function test__invoke()
+    {
+        $data = (object) array(
+            'href' => '/path/to/script.php',
+            'text' => '<span>this</span>',
+        );
+
+        $anchor = $this->helper;
+        $actual = $anchor($data->href, $data->text);
+        $expect = '<a href="/path/to/script.php"><span>this</span></a>';
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testWithAttribs()
+    {
+        $data = (object) array(
+            'href' => '/path/to/script.php',
+            'text' => '<span>foo</span>',
+            'attribs' => array('bar' => 'baz', 'href' => 'skip-me'),
+        );
+
+        $anchor = $this->helper;
+        $actual = $anchor($data->href, $data->text, $data->attribs);
+        $expect = '<a href="/path/to/script.php" bar="baz"><span>foo</span></a>';
+        $this->assertSame($expect, $actual);
+    }
+}


### PR DESCRIPTION
Added functionality in a separate helper as per pmjones comments:
https://github.com/auraphp/Aura.Html/pull/30#issuecomment-70100145
However, this feels redundant to me.

Adds the helper, the factory to the locator, and the test.
