### PR TITLE
Add support for "internal" styles and scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 php:
   - 5.3

--- a/README-HELPERS.md
+++ b/README-HELPERS.md
@@ -292,11 +292,45 @@ $helper->scripts->addCond(
     25                  // (int) optional priority order (default 100)
 ));
 
+// add an internal script
+$helper->scripts()->addInternal(
+    'alert("foo");',     // (string) script
+    1000                // (int) optional priority order (default 100)
+);
+
+// add an internal conditional script
+$helper->scripts()->addCondInternal(
+    'ie6',                // (string) the condition
+    'alert("ie6");',     // (string) script
+    1000                // (int) optional priority order (default 100)
+);
+
+// capture an internal script
+$helper->scripts()->beginInternal(
+    1000                // (int) optional priority order (default 100)
+);
+echo 'alert("captured")';
+$helper->scripts()->endInternal();
+
+// capture an internal conditional script
+$helper->scripts()->beginCondInternal(
+    'ie6',                    // (string) the condition
+    'alert("capture ie6");',  // (string) script
+    1000                      // (int) optional priority order (default 100)
+);
+echo 'alert("capture ie6")';
+$helper->scripts()->endInternal();
+
 ?>
 <!--[if ie6]><script src="/js/ie6.js" type="text/javascript"></script><![endif]-->
 <script src="/js/first.js" type="text/javascript"></script>
 <script src="/js/middle.js" type="text/javascript"></script>
 <script src="/js/last.js" type="text/javascript"></script>
+<script type="text/javascript">alert("foo");</script>
+<!--[if ie6]><script type="text/javascript">alert("ie6");</script><![endif]-->
+<script type="text/javascript">alert("captured");</script>
+<!--[if ie6]><script type="text/javascript">alert("capture ie6");</script><![endif]-->
+
 ```
 
 > N.b.: The `scriptsFoot()` helper works the same way, but is intended for placing a separate set of scripts at the end of the HTML body.
@@ -341,6 +375,38 @@ $helper->styles()->addCond(
     25                          // (int) optional priority order (default 100)
 );
 
+// add an internal style
+$helper->styles()->addInternal(
+    '.foo{color:red;}', // (string) style
+    null,              // (array) optional attributes
+    1000              // (int) optional priority order (default 100)
+);
+
+// add an internal conditional style
+$helper->styles()->addCondInternal(
+    'ie6',                 // (string) the condition
+    '.foo{color:pink;}',  // (string) style
+    null,                // (array) optional attributes
+    1000                // (int) optional priority order (default 100)
+);
+
+// capture an internal style
+$helper->styles()->beginInternal(
+    null,                // (array) optional attributes
+    1000,               // (int) optional priority order (default 100)
+);
+echo '.bar{color:red;}';
+$helper->styles()->endInternal();
+
+// capture an internal conditional style
+$helper->styles()->beginCondInternal(
+    'ie6',                // (string) the condition
+    null,                // (array) optional attributes
+    1000                // (int) optional priority order (default 100)
+);
+echo '.bar{color:pink;}';
+$helper->styles()->endInternal();
+
 // output the stylesheet links
 echo $helper->styles();
 ?>
@@ -348,6 +414,10 @@ echo $helper->styles();
 <link rel="stylesheet" href="/css/first.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="/css/middle.css" type="text/css" media="print" />
 <link rel="stylesheet" href="/css/last.css" type="text/css" media="screen" />
+<style type="text/css" media="screen">.foo{color:red;}</style>
+<!--[if ie6]><style type="text/css" media="screen">.foo{color:pink;}</style><![endif]-->
+<style type="text/css" media="screen">.bar{color:red;}</style>
+<!--[if ie6]><style type="text/css" media="screen">.bar{color:pink;}</style><![endif]-->
 ?>
 ```
 

--- a/src/Helper/Scripts.php
+++ b/src/Helper/Scripts.php
@@ -17,6 +17,8 @@ namespace Aura\Html\Helper;
  */
 class Scripts extends AbstractSeries
 {
+    private $capture;
+
     /**
      *
      * Adds a <script> tag to the stack.
@@ -65,5 +67,101 @@ class Scripts extends AbstractSeries
         $this->addElement($pos, $tag);
 
         return $this;
+    }
+
+    /**
+     * Adds internal script
+     *
+     * @param mixed $script The script
+     * @param int   $pos    The script position in the stack.
+     *
+     * @return Scripts
+     *
+     * @access public
+     */
+    public function addInternal($script, $pos = 100)
+    {
+        $attr = $this->escaper->attr(array(
+            'type' => 'text/javascript'
+        ));
+        $tag = "<script $attr>$script</script>";
+        $this->addElement($pos, $tag);
+        return $this;
+    }
+
+    /**
+     * addCondInternal
+     *
+     * @param mixed $cond   The conditional expression for the script.
+     * @param mixed $script The script
+     * @param int   $pos    The script position in the stack.
+     *
+     * @return mixed
+     * @throws exceptionclass [description]
+     *
+     * @access public
+     */
+    public function addCondInternal($cond, $script, $pos = 100)
+    {
+        $cond = $this->escaper->html($cond);
+        $attr = $this->escaper->attr(array(
+            'type' => 'text/javascript',
+        ));
+        $tag = "<!--[if $cond]><script $attr>$script</script><![endif]-->";
+        $this->addElement($pos, $tag);
+
+        return $this;
+    }
+
+    /**
+     * Adds internal script
+     *
+     * @param int $pos The script position in the stack.
+     *
+     * @return Scripts
+     *
+     * @access public
+     */
+    public function beginInternal($pos = 100)
+    {
+        $this->capture[] = $pos;
+         ob_start();
+    }
+
+    /**
+     * beginInternalCond
+     *
+     * @param mixed $cond DESCRIPTION
+     * @param int   $pos  DESCRIPTION
+     *
+     * @return mixed
+     *
+     * @access public
+     */
+    public function beginCondInternal($cond, $pos = 100)
+    {
+        $this->capture[] = array($cond, $pos);
+        ob_start();
+    }
+
+    /**
+     * endInternal
+     *
+     * @return mixed
+     *
+     * @access public
+     */
+    public function endInternal()
+    {
+        $script = ob_get_clean();
+        $params = array_pop($this->capture);
+        if (is_array($params)) {
+            return $this->addCondInternal(
+                $params[0],
+                $script,
+                $params[1]
+            );
+        }
+        return $this->addInternal($script, $params);
     }
 }

--- a/src/Helper/Styles.php
+++ b/src/Helper/Styles.php
@@ -67,6 +67,161 @@ class Styles extends AbstractSeries
     }
 
     /**
+     * Returns a "style" tag
+     *
+     * @param mixed $css  The source CSS
+     * @param array $attr The attributes for the tag
+     *
+     * @return string
+     *
+     * @access protected
+     */
+    protected function style($css, array $attr = null)
+    {
+        $attr = $this->fixInternalAttr($attr);
+        $attr = $this->escaper->attr($attr);
+        return "<style $attr>$css</style>";
+    }
+
+    /**
+     * addInternal
+     *
+     * @param mixed $css  The source CSS
+     * @param array $attr Additional attributes for the <style> tag
+     * @param int   $pos  The position in the stack.
+     *
+     * @return self
+     *
+     * @access public
+     */
+    public function addInternal($css, array $attr = null, $pos = 100)
+    {
+        $style = $this->style($css, $attr);
+        $this->addElement($pos, $style);
+        return $this;
+    }
+
+    /**
+     *
+     * Adds a conditional `<!--[if ...]><style ... /><![endif] -->`
+     * tag to the stack.
+     *
+     * @param string $cond The conditional expression for the css.
+     *
+     * @param string $css The source css.
+     *
+     * @param array $attr Additional attributes for the <style> tag.
+     *
+     * @param string $pos The position in the stack.
+     *
+     * @return self
+     *
+     */
+    public function addCondInternal($cond, $css, array $attr = null, $pos = 100)
+    {
+        $style = $this->style($css, $attr);
+        $cond  = $this->escaper->html($cond);
+        $tag  = "<!--[if $cond]>$style<![endif]-->";
+        $this->addElement($pos, $tag);
+
+        return $this;
+    }
+
+    /**
+     * Begins output buffering for a conditional style tag
+     *
+     * @param array $attr Additional attributes for the <style> tag.
+     * @param int   $pos  The style position in the stack
+     *
+     * @return void
+     *
+     * @access public
+     */
+    public function beginInternal(array $attr = null, $pos = 100)
+    {
+        $this->capture[] = array(
+            'attr' => $attr,
+            'pos' => $pos
+        );
+
+         ob_start();
+    }
+
+    /**
+     * Begins output buffering for a conditional style tag
+     *
+     * @param mixed $cond The conditional expression for the css
+     * @param array $attr Additional attributes for the <style> tag.
+     * @param int   $pos  The style position in the stack
+     *
+     * @return void
+     *
+     * @access public
+     */
+    public function beginCondInternal($cond, array $attr = null, $pos = 100)
+    {
+        $this->capture[] = array(
+            'attr' => $attr,
+            'pos' => $pos,
+            'cond' => $cond
+        );
+
+         ob_start();
+    }
+
+    /**
+     * Ends buffering and retains output for the most-recent internal.
+     *
+     * @return self
+     *
+     * @access public
+     */
+    public function endInternal()
+    {
+        $params = array_pop($this->capture);
+        $css = ob_get_clean();
+
+        if (isset($params['cond'])) {
+            return $this->addCondInternal(
+                $params['cond'],
+                $css,
+                $params['attr'],
+                $params['pos']
+            );
+        }
+
+        return $this->addInternal(
+            $css,
+            $params['attr'],
+            $params['pos']
+        );
+    }
+
+    /**
+     * Fixes the attributes for the internal stylesheet.
+     *
+     * @param array $attr Additional attributes for the <style> tag.
+     *
+     * @return array
+     *
+     * @access protected
+     */
+    protected function fixInternalAttr(array $attr = null)
+    {
+        $attr = (array) $attr;
+
+        $base = array(
+            'type' => 'text/css',
+            'media' => 'screen',
+        );
+
+        unset($attr['rel']);
+        unset($attr['href']);
+
+        return array_merge($base, (array) $attr);
+    }
+
+    /**
      *
      * Fixes the attributes for the stylesheet.
      *

--- a/tests/Helper/ScriptsTest.php
+++ b/tests/Helper/ScriptsTest.php
@@ -37,4 +37,30 @@ class ScriptsTest extends AbstractHelperTest
 
         $this->assertSame($expect, $actual);
     }
+
+    public function testInternal()
+    {
+        $scripts = $this->helper;
+        $scripts->addInternal('alert("foo");');
+        $scripts->addCondInternal('ie6', 'alert("ie6");');
+
+        $scripts->beginInternal();
+        echo 'alert("captured");';
+        $scripts->endInternal();
+
+        $scripts->beginCondInternal('ie6');
+        echo 'alert("captured ie6");';
+        $scripts->endInternal();
+
+
+        $actual = $scripts->__toString();
+
+        $expect = '    <script type="text/javascript">alert("foo");</script>' . PHP_EOL
+            . '    <!--[if ie6]><script type="text/javascript">alert("ie6");</script><![endif]-->' . PHP_EOL
+            . '    <script type="text/javascript">alert("captured");</script>' . PHP_EOL
+            . '    <!--[if ie6]><script type="text/javascript">alert("captured ie6");</script><![endif]-->' . PHP_EOL;
+
+
+        $this->assertSame($expect, $actual);
+    }
 }

--- a/tests/Helper/StylesTest.php
+++ b/tests/Helper/StylesTest.php
@@ -54,4 +54,29 @@ class StylesTest extends AbstractHelperTest
 
         $this->assertSame($expect, $actual);
     }
+
+    public function testInternal()
+    {
+        $styles = $this->helper;
+        $styles->addInternal('.foo{color:red;}');
+        $styles->addCondInternal('ie6', '.foo{color:yellow;}');
+
+        $styles->beginInternal();
+        echo ".bar{color:green;}";
+        $styles->endInternal();
+
+        $styles->beginCondInternal('ie6');
+        echo ".bar{color:pink;}";
+        $styles->endInternal();
+
+
+        $actual = $styles->__toString();
+
+        $expect = '    <style type="text/css" media="screen">.foo{color:red;}</style>' . PHP_EOL
+            . '    <!--[if ie6]><style type="text/css" media="screen">.foo{color:yellow;}</style><![endif]-->' . PHP_EOL
+            . '    <style type="text/css" media="screen">.bar{color:green;}</style>' . PHP_EOL
+            . '    <!--[if ie6]><style type="text/css" media="screen">.bar{color:pink;}</style><![endif]-->' . PHP_EOL;
+
+        $this->assertSame($expect, $actual);
+    }
 }


### PR DESCRIPTION
Add methods to Styles and Scripts helpers to:
- add internal assets
- add conditional internal assets
- capture internal assets
- capture conditional internal assets

Add tests and docs as well.

This way I can do things like this in my views:

``` php

$this->scripts()->addInternal(
    file_get_contents('./my-script-thing.js')
);

// or more useful:

$this->styles()->addInternal(
    $this->render('style-thing', $someData)
);

$this->styles()->beginInternal();

foreach ($colors as $class => $color) {
    echo sprintf(
        '%s {color:%s;}',
        $class,
        $color
    );
}
$this->styles()->endInternal();

```

Similar to ZF view helpers `captureStart`/`captureEnd` and `setScript`, etc.

Thoughts?
