### PR TITLE
Add Helper\Title::get()

### DIFF
--- a/src/Helper/Title.php
+++ b/src/Helper/Title.php
@@ -90,6 +90,18 @@ class Title extends AbstractHelper
 
     /**
      *
+     * Gets the currently set title string without HTML tag
+     *
+     * @return string
+     *
+     */
+    public function get()
+    {
+        return $this->title;
+    }
+
+    /**
+     *
      * Escapes and appends text to the end of the current <title> string.
      *
      * @param string $text The string to be appended to the title.

--- a/tests/Helper/TitleTest.php
+++ b/tests/Helper/TitleTest.php
@@ -81,4 +81,17 @@ class TitleTest extends AbstractHelperTest
         $expect = '  <title>This and That</title>' . PHP_EOL;
         $this->assertSame($expect, $actual);
     }
+
+    public function testGet()
+    {
+        $title = $this->helper;
+        $this->assertInstanceOf('Aura\Html\Helper\Title', $title);
+
+        $title->set('Bar');
+        $title->prepend('Foo ');
+
+        $actual = $title->get();
+        $expect = 'Foo Bar';
+        $this->assertSame($expect, $actual);
+    }
 }


### PR DESCRIPTION
This makes it so I can get the text of the title property without the HTML for
use elsewhere in a layout. For example:

``` php
<?php
// page.php

$this->title('Page Title');
//...
```

``` php
<?php
// layout.php

$this->metas()->add(
    'name' => 'title',
    'property' => 'og:title',
    'content' => $this->title()->get()
);

$this->title()->prepend('Site Title: ');
//...
```

Thoughts?
