### PR TITLE
Add support for phpunit 5 code coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,4 +4,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+      <whitelist processUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">./src</directory>
+      </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Add whitelist to phpunit config as per requirement of phpunit 5:

> It is now mandatory to configure a whitelist for code coverage analysis
> https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.0.md#changed-2

(I'm _pretty_ sure this is how you do this. ...it seems to work.)
