### PR TITLE
fix checked attribute for multi checkbox

### DIFF
--- a/src/Helper/Input/AbstractChecked.php
+++ b/src/Helper/Input/AbstractChecked.php
@@ -98,11 +98,11 @@ abstract class AbstractChecked extends AbstractInput
         }
 
         if ($this->strict) {
-            $this->attribs['checked'] = $this->value === $this->attribs['value'];
+            $this->attribs['checked'] = in_array($this->attribs['value'], (array)$this->value, true);
             return;
         }
 
-        $this->attribs['checked'] = $this->value == $this->attribs['value'];
+        $this->attribs['checked'] = in_array($this->attribs['value'], (array)$this->value, false);
     }
 
     /**

--- a/tests/Helper/Input/CheckboxTest.php
+++ b/tests/Helper/Input/CheckboxTest.php
@@ -154,7 +154,7 @@ class CheckboxTest extends AbstractHelperTest
         $checkbox = $this->helper;
         $actual = $checkbox(array(
             'name' => 'foo',
-            'value' => ['yes', 'no'],
+            'value' => array('yes', 'no'),
             'options' => array(
                 'yes' => 'Yes',
                 'no' => 'No',

--- a/tests/Helper/Input/CheckboxTest.php
+++ b/tests/Helper/Input/CheckboxTest.php
@@ -149,4 +149,25 @@ class CheckboxTest extends AbstractHelperTest
                 . '<label><input type="checkbox" name="foo[]" value="maybe" /> Maybe</label>' . PHP_EOL;
         $this->assertSame($expect, $actual);
     }
+
+    public function testMultiCheckboxWithValues() {
+        $checkbox = $this->helper;
+        $actual = $checkbox(array(
+            'name' => 'foo',
+            'value' => ['yes', 'no'],
+            'options' => array(
+                'yes' => 'Yes',
+                'no' => 'No',
+                'maybe' => 'Maybe'
+            ),
+            'attribs' => array(
+                'value' => 'yes',
+                'label' => 'Is ignored',
+            )
+        ))->__toString();
+        $expect = '<label><input type="checkbox" name="foo[]" value="yes" checked /> Yes</label>' . PHP_EOL
+            . '<label><input type="checkbox" name="foo[]" value="no" checked /> No</label>' . PHP_EOL
+            . '<label><input type="checkbox" name="foo[]" value="maybe" /> Maybe</label>' . PHP_EOL;
+        $this->assertSame($expect, $actual);
+    }
 }


### PR DESCRIPTION
This commit makes possible to have more than one checked element in a multi-checkbox input
