### PR TITLE
Add Void Helper

### DIFF
--- a/README-HELPERS.md
+++ b/README-HELPERS.md
@@ -14,6 +14,7 @@ Use a helper by calling it as a method on the _HelperLocator_. The available hel
 - [tag](#tag)
 - [title](#title)
 - [ul](#ul)
+- [void](#void)
 
 There is also a series of [helpers for forms](https://github.com/auraphp/Aura.Html/blob/2.x/README-FORMS.md).
 
@@ -540,4 +541,17 @@ echo $helper->ul();
     <li><a href="/next">Next</a></li>
     <li><a href="/last">Last</a></li>
 </ul>
+```
+
+## void
+
+Helper for self closing void tags.
+
+```html+php
+<?php
+echo $helper->void('meta', ['itemprop' => 'duration', 'content' => 'T1M33S']);
+echo $helper->void('br');
+?>
+<meta itemprop="duration" content="T1M33S" />
+<br  />
 ```

--- a/src/Helper/Void.php
+++ b/src/Helper/Void.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Html\Helper;
+
+/**
+ *
+ * Helper to generate any void tag.
+ *
+ * @package Aura.Html
+ *
+ */
+class Void extends AbstractHelper
+{
+    /**
+     *
+     * Returns any kind of void tag with attributes.
+     *
+     * @param string $tag The tag to generate.
+     *
+     * @param array $attr Attributes for the tag.
+     *
+     * @return string
+     *
+     */
+    public function __invoke($tag, array $attr = array())
+    {
+        return $this->void($tag, $attr);
+    }
+}

--- a/src/HelperLocatorFactory.php
+++ b/src/HelperLocatorFactory.php
@@ -77,6 +77,7 @@ class HelperLocatorFactory
             'tag'               => function () use ($escaper) { return new Helper\Tag($escaper); },
             'title'             => function () use ($escaper) { return new Helper\Title($escaper); },
             'ul'                => function () use ($escaper) { return new Helper\Ul($escaper); },
+            'void'              => function () use ($escaper) { return new Helper\Void($escaper); }
         ));
     }
 

--- a/tests/Helper/VoidTest.php
+++ b/tests/Helper/VoidTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace Aura\Html\Helper;
+
+class VoidTest extends AbstractHelperTest
+{
+    public function test()
+    {
+        $tag = $this->helper;
+
+        $actual = $tag('meta', array(
+            'itemprop' => 'duration',
+            'content' => 'T1M33S',
+        ));
+
+        $expect = '<meta itemprop="duration" content="T1M33S" />';
+
+        $this->assertSame($expect, $actual);
+
+        $actual = $tag('br');
+        $expect = '<br  />';
+        $this->assertSame($expect, $actual);
+    }
+}


### PR DESCRIPTION
Add helper for use with "[void](https://www.w3.org/TR/html5/syntax.html#void-elements)" 'self closing' tags, eg:
- area, 
- base, 
- br, 
- col, 
- embed, 
- hr, 
- keygen, 
- param, 
- source,
- track
- wbr
