### PR TITLE
Add method to add scripts with additional attributes

### DIFF
--- a/README-HELPERS.md
+++ b/README-HELPERS.md
@@ -323,8 +323,10 @@ echo 'alert("capture ie6")';
 $helper->scripts()->endInternal();
 
 // add a script tag with additional attributes
-$helper->script()->addAttr(
+// by passing an attribute array as the last parameter of any of the method
+$helper->scripts()->add(
     'https://cdn.tld/foo.js',
+    100,
     [
         'async' => true,
         'defer' => true,

--- a/README-HELPERS.md
+++ b/README-HELPERS.md
@@ -322,6 +322,17 @@ $helper->scripts()->beginCondInternal(
 echo 'alert("capture ie6")';
 $helper->scripts()->endInternal();
 
+// add a script tag with additional attributes
+$helper->script()->addAttr(
+    'https://cdn.tld/foo.js',
+    [
+        'async' => true,
+        'defer' => true,
+        'crossorigin' => 'anonymous',
+        'integrity' => 'sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo='
+    ]
+);
+
 ?>
 <!--[if ie6]><script src="/js/ie6.js" type="text/javascript"></script><![endif]-->
 <script src="/js/first.js" type="text/javascript"></script>
@@ -331,6 +342,7 @@ $helper->scripts()->endInternal();
 <!--[if ie6]><script type="text/javascript">alert("ie6");</script><![endif]-->
 <script type="text/javascript">alert("captured");</script>
 <!--[if ie6]><script type="text/javascript">alert("capture ie6");</script><![endif]-->
+<script src="http://cdn.tld/foo.js" type="text/javascript" async defer crossorigin="anonymous" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo="></script>
 
 ```
 

--- a/src/Helper/Scripts.php
+++ b/src/Helper/Scripts.php
@@ -27,48 +27,14 @@ class Scripts extends AbstractSeries
      *
      * @param int $pos The script position in the stack.
      *
-     * @return null
+     * @param array $attr The additional attributes
+     *
+     * @return self
      *
      */
-    public function add($src, $pos = 100)
+    public function add($src, $pos = 100, array $attr = array())
     {
-        $attr = $this->escaper->attr(array(
-            'src' => $src,
-            'type' => 'text/javascript',
-        ));
-        $tag = "<script $attr></script>";
-        $this->addElement($pos, $tag);
-
-        return $this;
-    }
-
-    /**
-     *
-     * Adds a <script> tag to the stack with additional attributes
-     *
-     * @param string $src The source href for the script.
-     *
-     * @param string $attr The additional attributes
-     *
-     * @param int $pos The script position in the stack.
-     *
-     * @return null
-     *
-     */
-    public function addAttr($src, array $attr = null, $pos = 100)
-    {
-        $attr = (array) $attr;
-
-        $base = array(
-            'src' => $src,
-            'type' => 'text/javascript',
-        );
-
-        unset($attr['src']);
-        unset($attr['type']);
-
-        $attr = $this->escaper->attr(array_merge($base, $attr));
-
+        $attr = $this->attr($src, $attr);
         $tag = "<script $attr></script>";
         $this->addElement($pos, $tag);
 
@@ -86,16 +52,15 @@ class Scripts extends AbstractSeries
      *
      * @param string $pos The script position in the stack.
      *
-     * @return null
+     * @param array $attr The additional attributes
+     *
+     * @return self
      *
      */
-    public function addCond($cond, $src, $pos = 100)
+    public function addCond($cond, $src, $pos = 100, array $attr = array())
     {
         $cond = $this->escaper->html($cond);
-        $attr = $this->escaper->attr(array(
-            'src' => $src,
-            'type' => 'text/javascript',
-        ));
+        $attr = $this->attr($src, $attr);
         $tag = "<!--[if $cond]><script $attr></script><![endif]-->";
         $this->addElement($pos, $tag);
 
@@ -107,39 +72,36 @@ class Scripts extends AbstractSeries
      *
      * @param mixed $script The script
      * @param int   $pos    The script position in the stack.
+     * @param array $attr The additional attributes
      *
-     * @return Scripts
+     * @return self
      *
      * @access public
      */
-    public function addInternal($script, $pos = 100)
+    public function addInternal($script, $pos = 100, array $attr = array())
     {
-        $attr = $this->escaper->attr(array(
-            'type' => 'text/javascript'
-        ));
+        $attr = $this->attr(null, $attr);
         $tag = "<script $attr>$script</script>";
         $this->addElement($pos, $tag);
         return $this;
     }
 
     /**
-     * addCondInternal
+     * Add Conditional internal script
      *
      * @param mixed $cond   The conditional expression for the script.
      * @param mixed $script The script
      * @param int   $pos    The script position in the stack.
+     * @param array $attr   The additional attributes
      *
-     * @return mixed
-     * @throws exceptionclass [description]
+     * @return self
      *
      * @access public
      */
-    public function addCondInternal($cond, $script, $pos = 100)
+    public function addCondInternal($cond, $script, $pos = 100, array $attr = array())
     {
         $cond = $this->escaper->html($cond);
-        $attr = $this->escaper->attr(array(
-            'type' => 'text/javascript',
-        ));
+        $attr = $this->attr(null, $attr);
         $tag = "<!--[if $cond]><script $attr>$script</script><![endif]-->";
         $this->addElement($pos, $tag);
 
@@ -149,36 +111,39 @@ class Scripts extends AbstractSeries
     /**
      * Adds internal script
      *
-     * @param int $pos The script position in the stack.
+     * @param int   $pos  The script position in the stack.
+     * @param array $attr The additional attributes
      *
-     * @return Scripts
+     *
+     * @return null
      *
      * @access public
      */
-    public function beginInternal($pos = 100)
+    public function beginInternal($pos = 100, array $attr = array())
     {
-        $this->capture[] = $pos;
+        $this->capture[] = array($pos, $attr);
          ob_start();
     }
 
     /**
-     * beginInternalCond
+     * Begin Conditional Internal Capture
      *
-     * @param mixed $cond DESCRIPTION
-     * @param int   $pos  DESCRIPTION
+     * @param mixed $cond condition
+     * @param int   $pos  position
+     * @param array $attr The additional attributes
      *
-     * @return mixed
+     * @return null
      *
      * @access public
      */
-    public function beginCondInternal($cond, $pos = 100)
+    public function beginCondInternal($cond, $pos = 100, array $attr = array())
     {
-        $this->capture[] = array($cond, $pos);
+        $this->capture[] = array($cond, $pos, $attr);
         ob_start();
     }
 
     /**
-     * endInternal
+     * End internal script capture
      *
      * @return mixed
      *
@@ -188,13 +153,33 @@ class Scripts extends AbstractSeries
     {
         $script = ob_get_clean();
         $params = array_pop($this->capture);
-        if (is_array($params)) {
+        if (count($params) > 2) {
             return $this->addCondInternal(
                 $params[0],
                 $script,
-                $params[1]
+                $params[1],
+                $params[2]
             );
         }
-        return $this->addInternal($script, $params);
+        return $this->addInternal($script, $params[0], $params[1]);
+    }
+
+    /**
+     * Fix and escape script attributes
+     *
+     * @param mixed $src  script source
+     * @param array $attr additional attributes
+     *
+     * @return string
+     *
+     * @access protected
+     */
+    protected function attr($src = null, array $attr = array())
+    {
+        if (null !== $src) {
+            $attr['src'] = $src;
+        }
+        $attr['type'] = 'text/javascript';
+        return $this->escaper->attr($attr);
     }
 }

--- a/src/Helper/Scripts.php
+++ b/src/Helper/Scripts.php
@@ -44,6 +44,39 @@ class Scripts extends AbstractSeries
 
     /**
      *
+     * Adds a <script> tag to the stack with additional attributes
+     *
+     * @param string $src The source href for the script.
+     *
+     * @param string $attr The additional attributes
+     *
+     * @param int $pos The script position in the stack.
+     *
+     * @return null
+     *
+     */
+    public function addAttr($src, array $attr = null, $pos = 100)
+    {
+        $attr = (array) $attr;
+
+        $base = array(
+            'src' => $src,
+            'type' => 'text/javascript',
+        );
+
+        unset($attr['src']);
+        unset($attr['type']);
+
+        $attr = $this->escaper->attr(array_merge($base, $attr));
+
+        $tag = "<script $attr></script>";
+        $this->addElement($pos, $tag);
+
+        return $this;
+    }
+
+    /**
+     *
      * Adds a conditional `<!--[if ...]><script><![endif] -->` tag to the
      * stack.
      *

--- a/tests/Helper/ScriptsTest.php
+++ b/tests/Helper/ScriptsTest.php
@@ -25,12 +25,14 @@ class ScriptsTest extends AbstractHelperTest
 
         $scripts->add('/js/last.js', 150);
         $scripts->add('/js/first.js', 50);
+        $scripts->addAttr('/js/attr.js', array('foo' => true, 'bar' => 'baz'));
         $scripts->add('/js/middle.js');
         $scripts->addCond('ie6', '/js/ie6.js');
 
         $actual = $scripts->__toString();
 
         $expect = '    <script src="/js/first.js" type="text/javascript"></script>' . PHP_EOL
+                . '    <script src="/js/attr.js" type="text/javascript" foo bar="baz"></script>'. PHP_EOL
                 . '    <script src="/js/middle.js" type="text/javascript"></script>' . PHP_EOL
                 . '    <!--[if ie6]><script src="/js/ie6.js" type="text/javascript"></script><![endif]-->' . PHP_EOL
                 . '    <script src="/js/last.js" type="text/javascript"></script>' . PHP_EOL;

--- a/tests/Helper/ScriptsTest.php
+++ b/tests/Helper/ScriptsTest.php
@@ -25,14 +25,14 @@ class ScriptsTest extends AbstractHelperTest
 
         $scripts->add('/js/last.js', 150);
         $scripts->add('/js/first.js', 50);
-        $scripts->addAttr('/js/attr.js', array('foo' => true, 'bar' => 'baz'));
+        $scripts->add('/js/attr.js', 100, array('foo' => true, 'bar' => 'baz', 'bing' => 'true'));
         $scripts->add('/js/middle.js');
         $scripts->addCond('ie6', '/js/ie6.js');
 
         $actual = $scripts->__toString();
 
         $expect = '    <script src="/js/first.js" type="text/javascript"></script>' . PHP_EOL
-                . '    <script src="/js/attr.js" type="text/javascript" foo bar="baz"></script>'. PHP_EOL
+                . '    <script foo bar="baz" bing="true" src="/js/attr.js" type="text/javascript"></script>'. PHP_EOL
                 . '    <script src="/js/middle.js" type="text/javascript"></script>' . PHP_EOL
                 . '    <!--[if ie6]><script src="/js/ie6.js" type="text/javascript"></script><![endif]-->' . PHP_EOL
                 . '    <script src="/js/last.js" type="text/javascript"></script>' . PHP_EOL;


### PR DESCRIPTION
Adds ability to use [SRI](https://www.w3.org/TR/SRI/), [async, defer](https://www.w3.org/TR/html5/scripting-1.html#attr-script-async), etc.

Would have like to mess with the existing methods, but that that'd be breaking change, so added an additional method: `addAttr`.

On a side note, any thoughts on going 3.x with this?
