### PR TITLE
Rename Void helper to VoidTag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - composer self-update
   - composer install
 script:
-  - phpunit --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         }
     },
     "require-dev": {
-        "aura/di": "~2.0"
+        "aura/di": "~2.0",
+        "phpunit/phpunit": "~5.7 || ~4.8"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Helper/VoidTag.php
+++ b/src/Helper/VoidTag.php
@@ -15,7 +15,7 @@ namespace Aura\Html\Helper;
  * @package Aura.Html
  *
  */
-class Void extends AbstractHelper
+class VoidTag extends AbstractHelper
 {
     /**
      *

--- a/src/HelperLocatorFactory.php
+++ b/src/HelperLocatorFactory.php
@@ -81,7 +81,7 @@ class HelperLocatorFactory
             'tag'               => function () use ($escaper) { return new Helper\Tag($escaper); },
             'title'             => function () use ($escaper) { return new Helper\Title($escaper); },
             'ul'                => function () use ($escaper) { return new Helper\Ul($escaper); },
-            'void'              => function () use ($escaper) { return new Helper\Void($escaper); }
+            'void'              => function () use ($escaper) { return new Helper\VoidTag($escaper); }
         ));
     }
 

--- a/tests/Helper/VoidTagTest.php
+++ b/tests/Helper/VoidTagTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Html\Helper;
 
-class VoidTest extends AbstractHelperTest
+class VoidTagTest extends AbstractHelperTest
 {
     public function test()
     {


### PR DESCRIPTION
PHP 7.1: Cannot use 'Void' as class name as it is reserved