### PR TITLE
update tests and ci starts from 5.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,6 @@ jobs:
         operating-system:
           - ubuntu-latest
         php-version:
-          - '5.3'
           - '5.4'
           - '5.5'
           - '5.6'

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /tests/container/composer.*
 /composer.lock
 /vendor
+/.phpunit.result.cache

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="./phpunit.php">
-    <testsuites>
-        <testsuite>
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-      <whitelist processUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">./src</directory>
-      </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./phpunit.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Aura.Html test suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Escaper/AbstractEscaperTest.php
+++ b/tests/Escaper/AbstractEscaperTest.php
@@ -2,6 +2,7 @@
 namespace Aura\Html\Escaper;
 
 use Aura\Html\FakePhp;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 // trick PHP into using this function instead of the native function
 function function_exists($name)
@@ -17,13 +18,13 @@ function function_exists($name)
  * under the New BSD License (http://framework.zend.com/license/new-bsd).
  *
  */
-abstract class AbstractEscaperTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractEscaperTest extends TestCase
 {
     protected $escaper;
 
     abstract public function test__construct();
 
-    protected function setUp()
+    protected function set_up()
     {
         FakePhp::$function_exists['iconv'] = \function_exists('iconv');
         FakePhp::$function_exists['mb_convert_encoding'] = \function_exists('mb_convert_encoding');
@@ -52,7 +53,7 @@ abstract class AbstractEscaperTest extends \PHPUnit_Framework_TestCase
         FakePhp::$function_exists['iconv'] = false;
         FakePhp::$function_exists['mb_convert_encoding'] = false;
         $this->escaper->setEncoding('iso-8859-1');
-        $this->setExpectedException('Aura\Html\Exception\ExtensionNotInstalled');
+        $this->expectException('Aura\Html\Exception\ExtensionNotInstalled');
         $this->escaper->toUtf8('x');
     }
 
@@ -61,7 +62,7 @@ abstract class AbstractEscaperTest extends \PHPUnit_Framework_TestCase
         $this->escaper->setEncoding('macroman');
         $this->assertEquals('macroman', $this->escaper->getEncoding());
 
-        $this->setExpectedException('Aura\Html\Exception\EncodingNotSupported');
+        $this->expectException('Aura\Html\Exception\EncodingNotSupported');
         $this->escaper->setEncoding('invalid-encoding');
     }
 
@@ -75,7 +76,7 @@ abstract class AbstractEscaperTest extends \PHPUnit_Framework_TestCase
     public function testToUtf8_invalid()
     {
         // http://stackoverflow.com/questions/11709410/regex-to-detect-invalid-utf-8-string
-        $this->setExpectedException('Aura\Html\Exception\InvalidUtf8');
+        $this->expectException('Aura\Html\Exception\InvalidUtf8');
         $this->escaper->toUtf8(chr(0xC0) . chr(0x80));
     }
 

--- a/tests/Escaper/AttrEscaperTest.php
+++ b/tests/Escaper/AttrEscaperTest.php
@@ -11,9 +11,9 @@ namespace Aura\Html\Escaper;
  */
 class AttrEscaperTest extends AbstractEscaperTest
 {
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->escaper = new AttrEscaper(new HtmlEscaper);
     }
 

--- a/tests/Escaper/CssEscaperTest.php
+++ b/tests/Escaper/CssEscaperTest.php
@@ -11,9 +11,9 @@ namespace Aura\Html\Escaper;
  */
 class CssEscaperTest extends AbstractEscaperTest
 {
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->escaper = new CssEscaper;
     }
 

--- a/tests/Escaper/HtmlEscaperTest.php
+++ b/tests/Escaper/HtmlEscaperTest.php
@@ -11,9 +11,9 @@ namespace Aura\Html\Escaper;
  */
 class HtmlEscaperTest extends AbstractEscaperTest
 {
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->escaper = new HtmlEscaper;
     }
 

--- a/tests/Escaper/JsEscaperTest.php
+++ b/tests/Escaper/JsEscaperTest.php
@@ -11,9 +11,9 @@ namespace Aura\Html\Escaper;
  */
 class JsEscaperTest extends AbstractEscaperTest
 {
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->escaper = new JsEscaper;
     }
 

--- a/tests/EscaperTest.php
+++ b/tests/EscaperTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aura\Html;
 
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
 /**
  *
  * Based almost entirely on Zend\Escaper by Padraic Brady et al. and modified
@@ -9,11 +11,11 @@ namespace Aura\Html;
  * under the New BSD License (http://framework.zend.com/license/new-bsd).
  *
  */
-class EscaperTest extends \PHPUnit_Framework_TestCase
+class EscaperTest extends TestCase
 {
     protected $escaper;
 
-    public function setUp()
+    public function set_up()
     {
         $escaper_factory = new EscaperFactory;
         $this->escaper = $escaper_factory->newInstance();

--- a/tests/Helper/AbstractHelperTest.php
+++ b/tests/Helper/AbstractHelperTest.php
@@ -2,14 +2,15 @@
 namespace Aura\Html\Helper;
 
 use Aura\Html\EscaperFactory;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-abstract class AbstractHelperTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractHelperTest extends TestCase
 {
     protected $helper;
 
-    protected function setUp()
+    protected function set_up()
     {
-        parent::setUp();
+        parent::set_up();
         $this->helper = $this->newHelper();
     }
 

--- a/tests/HelperLocatorTest.php
+++ b/tests/HelperLocatorTest.php
@@ -1,11 +1,13 @@
 <?php
 namespace Aura\Html;
 
-class HelperLocatorTest extends \PHPUnit_Framework_TestCase
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class HelperLocatorTest extends TestCase
 {
     protected $helper_locator;
 
-    protected function setUp()
+    protected function set_up()
     {
         $factory = new HelperLocatorFactory;
         $this->helper_locator = $factory->newInstance();
@@ -25,7 +27,7 @@ class HelperLocatorTest extends \PHPUnit_Framework_TestCase
         $actual = $this->helper_locator->mockHelper('World');
         $this->assertSame($expect, $actual);
 
-        $this->setExpectedException('Aura\Html\Exception\HelperNotFound');
+        $this->expectException('Aura\Html\Exception\HelperNotFound');
         $this->helper_locator->get('noSuchHelper');
     }
 


### PR DESCRIPTION
@koriym Aura.Html is supporting from 5.3 onwards. 

We cannot support 5.3 tests, yoast/polyfill only starts with 5.4 .

So without a CI we cannot support 5.3 and probably as a convenience we should update the composer.json php version to 5.4.0 so that only php versions that support will get installed. So no accidental damage. That may be considered as a BC break though.