### PR TITLE
Remove deprecated type attribute from link and script tags

### DIFF
--- a/src/Helper/Scripts.php
+++ b/src/Helper/Scripts.php
@@ -88,7 +88,7 @@ class Scripts extends AbstractSeries
     public function addInternal($script, $pos = 100, array $attr = array())
     {
         $attr = $this->attr(null, $attr);
-        $tag = "<script $attr>$script</script>";
+        $tag = $attr ? "<script $attr>$script</script>" : "<script>$script</script>";
         $this->addElement($pos, $tag);
         return $this;
     }
@@ -109,7 +109,7 @@ class Scripts extends AbstractSeries
     {
         $cond = $this->escaper->html($cond);
         $attr = $this->attr(null, $attr);
-        $tag = "<!--[if $cond]><script $attr>$script</script><![endif]-->";
+        $tag = $attr ? "<!--[if $cond]><script $attr>$script</script><![endif]-->" : "<!--[if $cond]><script>$script</script><![endif]-->";
         $this->addElement($pos, $tag);
 
         return $this;
@@ -186,7 +186,6 @@ class Scripts extends AbstractSeries
         if (null !== $src) {
             $attr['src'] = $src;
         }
-        $attr['type'] = 'text/javascript';
         return $this->escaper->attr($attr);
     }
 }

--- a/src/Helper/Styles.php
+++ b/src/Helper/Styles.php
@@ -245,7 +245,6 @@ class Styles extends AbstractSeries
         $base = array(
             'rel'   => 'stylesheet',
             'href'  => $href,
-            'type'  => 'text/css',
             'media' => 'screen',
         );
 

--- a/tests/Helper/ScriptsTest.php
+++ b/tests/Helper/ScriptsTest.php
@@ -14,7 +14,7 @@ class ScriptsTest extends AbstractHelperTest
         $this->assertInstanceOf('Aura\Html\Helper\Scripts', $actual);
 
         $actual = $scripts('script.js')->__toString();
-        $expect = '    <script src="script.js" type="text/javascript"></script>' . PHP_EOL;
+        $expect = '    <script src="script.js"></script>' . PHP_EOL;
         $this->assertSame($expect, $actual);
     }
 
@@ -31,11 +31,11 @@ class ScriptsTest extends AbstractHelperTest
 
         $actual = $scripts->__toString();
 
-        $expect = '    <script src="/js/first.js" type="text/javascript"></script>' . PHP_EOL
-                . '    <script foo bar="baz" bing="true" src="/js/attr.js" type="text/javascript"></script>'. PHP_EOL
-                . '    <script src="/js/middle.js" type="text/javascript"></script>' . PHP_EOL
-                . '    <!--[if ie6]><script src="/js/ie6.js" type="text/javascript"></script><![endif]-->' . PHP_EOL
-                . '    <script src="/js/last.js" type="text/javascript"></script>' . PHP_EOL;
+        $expect = '    <script src="/js/first.js"></script>' . PHP_EOL
+                . '    <script foo bar="baz" bing="true" src="/js/attr.js"></script>'. PHP_EOL
+                . '    <script src="/js/middle.js"></script>' . PHP_EOL
+                . '    <!--[if ie6]><script src="/js/ie6.js"></script><![endif]-->' . PHP_EOL
+                . '    <script src="/js/last.js"></script>' . PHP_EOL;
 
         $this->assertSame($expect, $actual);
     }
@@ -57,10 +57,10 @@ class ScriptsTest extends AbstractHelperTest
 
         $actual = $scripts->__toString();
 
-        $expect = '    <script type="text/javascript">alert("foo");</script>' . PHP_EOL
-            . '    <!--[if ie6]><script type="text/javascript">alert("ie6");</script><![endif]-->' . PHP_EOL
-            . '    <script type="text/javascript">alert("captured");</script>' . PHP_EOL
-            . '    <!--[if ie6]><script type="text/javascript">alert("captured ie6");</script><![endif]-->' . PHP_EOL;
+        $expect = '    <script>alert("foo");</script>' . PHP_EOL
+            . '    <!--[if ie6]><script>alert("ie6");</script><![endif]-->' . PHP_EOL
+            . '    <script>alert("captured");</script>' . PHP_EOL
+            . '    <!--[if ie6]><script>alert("captured ie6");</script><![endif]-->' . PHP_EOL;
 
 
         $this->assertSame($expect, $actual);

--- a/tests/Helper/StylesTest.php
+++ b/tests/Helper/StylesTest.php
@@ -14,7 +14,7 @@ class StylesTest extends AbstractHelperTest
         $this->assertInstanceOf('Aura\Html\Helper\Styles', $actual);
 
         $actual = $styles('style.css')->__toString();
-        $expect = '    <link rel="stylesheet" href="style.css" type="text/css" media="screen" />' . PHP_EOL;
+        $expect = '    <link rel="stylesheet" href="style.css" media="screen" />' . PHP_EOL;
         $this->assertSame($expect, $actual);
     }
 
@@ -28,10 +28,10 @@ class StylesTest extends AbstractHelperTest
         $styles->addCond('ie6', '/css/ie6.css');
 
         $actual = $styles->__toString();
-        $expect = '    <link rel="stylesheet" href="/css/first.css" type="text/css" media="screen" />' . PHP_EOL
-                . '    <link rel="stylesheet" href="/css/middle.css" type="text/css" media="screen" />' . PHP_EOL
-                . '    <!--[if ie6]><link rel="stylesheet" href="/css/ie6.css" type="text/css" media="screen" /><![endif]-->' . PHP_EOL
-                . '    <link rel="stylesheet" href="/css/last.css" type="text/css" media="screen" />' . PHP_EOL;
+        $expect = '    <link rel="stylesheet" href="/css/first.css" media="screen" />' . PHP_EOL
+                . '    <link rel="stylesheet" href="/css/middle.css" media="screen" />' . PHP_EOL
+                . '    <!--[if ie6]><link rel="stylesheet" href="/css/ie6.css" media="screen" /><![endif]-->' . PHP_EOL
+                . '    <link rel="stylesheet" href="/css/last.css" media="screen" />' . PHP_EOL;
 
         $this->assertSame($expect, $actual);
     }
@@ -47,10 +47,10 @@ class StylesTest extends AbstractHelperTest
         $styles->addCond('ie6', '/css/ie6.css', array('media' => 'print'));
         $actual = $styles->__toString();
 
-        $expect = '  <link rel="stylesheet" href="/css/first.css" type="text/css" media="screen" />' . PHP_EOL
-                . '  <link rel="stylesheet" href="/css/middle.css" type="text/css" media="print" />' . PHP_EOL
-                . '  <!--[if ie6]><link rel="stylesheet" href="/css/ie6.css" type="text/css" media="print" /><![endif]-->' . PHP_EOL
-                . '  <link rel="stylesheet" href="/css/last.css" type="text/css" media="screen" />' . PHP_EOL;
+        $expect = '  <link rel="stylesheet" href="/css/first.css" media="screen" />' . PHP_EOL
+                . '  <link rel="stylesheet" href="/css/middle.css" media="print" />' . PHP_EOL
+                . '  <!--[if ie6]><link rel="stylesheet" href="/css/ie6.css" media="print" /><![endif]-->' . PHP_EOL
+                . '  <link rel="stylesheet" href="/css/last.css" media="screen" />' . PHP_EOL;
 
         $this->assertSame($expect, $actual);
     }
@@ -72,10 +72,10 @@ class StylesTest extends AbstractHelperTest
 
         $actual = $styles->__toString();
 
-        $expect = '    <style type="text/css" media="screen">.foo{color:red;}</style>' . PHP_EOL
-            . '    <!--[if ie6]><style type="text/css" media="screen">.foo{color:yellow;}</style><![endif]-->' . PHP_EOL
-            . '    <style type="text/css" media="screen">.bar{color:green;}</style>' . PHP_EOL
-            . '    <!--[if ie6]><style type="text/css" media="screen">.bar{color:pink;}</style><![endif]-->' . PHP_EOL;
+        $expect = '    <style media="screen">.foo{color:red;}</style>' . PHP_EOL
+            . '    <!--[if ie6]><style media="screen">.foo{color:yellow;}</style><![endif]-->' . PHP_EOL
+            . '    <style media="screen">.bar{color:green;}</style>' . PHP_EOL
+            . '    <!--[if ie6]><style media="screen">.bar{color:pink;}</style><![endif]-->' . PHP_EOL;
 
         $this->assertSame($expect, $actual);
     }


### PR DESCRIPTION
## Summary

Following up on PR #64, this PR removes the remaining deprecated `type` attributes:

- Remove `type="text/css"` from `<link>` tags in `fixAttr()`
- Remove `type="text/javascript"` from `<script>` tags in `attr()`

In HTML5, `type="text/css"` for stylesheets and `type="text/javascript"` for scripts are the defaults and no longer required.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unnecessary type attributes from generated script and stylesheet HTML tags, resulting in cleaner, standards-compliant output.

* **Tests**
  * Updated test expectations to match simplified HTML output for scripts and stylesheets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->