### PR TITLE
Alternative approach for #43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 6.1.0
+
+- ADD: `Helper\Title::get()` to retrieve the HTML-escaped title string for use in HTML contexts.
+- ADD: `Helper\Title::getRaw()` to retrieve the unescaped title string for use in non-HTML contexts such as `og:title` meta tags. Reliable only when built with escaped methods (`set()`, `append()`, `prepend()`); unreliable when mixed with raw variants.
+- FIX: `Helper\Title::__toString()` no longer resets the title state after rendering, allowing `get()`, `getRaw()`, and further mutations to work correctly regardless of render order.
+- DOC: Added `@method` PHPDoc tags to `HelperLocator` for IDE autocomplete support (fixes #58).
+
 ## 6.0.0
 
 - PHP 8.4+ required

--- a/README-HELPERS.md
+++ b/README-HELPERS.md
@@ -530,7 +530,7 @@ $helper->title()->prepend('Site Name | ');
 echo $helper->title();
 ?>
 <meta name="title" property="og:title" content="Café &amp; Bistro" />
-<title>Site Name | Caf&eacute; &amp; Bistro</title>
+<title>Site Name | Café &amp; Bistro</title>
 ```
 
 > **Note:** `getRaw()` is only reliable when the title has been built exclusively

--- a/README-HELPERS.md
+++ b/README-HELPERS.md
@@ -507,6 +507,39 @@ echo $helper->title();
 <title>Pre2 > Pre1 > This & That > Suf1 > Suf2</title>
 ```
 
+### Reading back the title value
+
+Use `get()` to retrieve the HTML-escaped title string, and `getRaw()` to retrieve
+the original unescaped string. This is useful when you need to reuse the title
+in other contexts such as an `og:title` meta tag.
+
+```html+php
+<?php
+// In a child view (page.php):
+$helper->title()->set('Café & Bistro');
+
+// In the layout:
+$helper->metas()->add([
+    'name'     => 'title',
+    'property' => 'og:title',
+    'content'  => $helper->title()->getRaw(), // "Café & Bistro" — plain text, safe for attributes
+]);
+
+$helper->title()->prepend('Site Name | ');
+
+echo $helper->title();
+?>
+<meta name="title" property="og:title" content="Café &amp; Bistro" />
+<title>Site Name | Caf&eacute; &amp; Bistro</title>
+```
+
+> **Note:** `getRaw()` is only reliable when the title has been built exclusively
+> using the escaped methods (`set()`, `append()`, `prepend()`). If you mix in the
+> raw variants (`setRaw()`, `appendRaw()`, `prependRaw()`), the raw title will
+> contain whatever HTML was passed to those methods (including any entities or
+> markup), rather than plain text. In that case, `get()` remains correct for
+> HTML output, but `getRaw()` should not be relied upon for non-HTML contexts.
+
 ## ul
 
 Helper for `<ul>` tags with `<li>` items.  Build the set of items (both raw and escaped) then output them all at once.

--- a/src/Helper/Title.php
+++ b/src/Helper/Title.php
@@ -74,7 +74,7 @@ class Title extends AbstractHelper
      */
     public function get()
     {
-        return $this->title;
+        return (string) $this->title;
     }
 
     /**
@@ -87,7 +87,7 @@ class Title extends AbstractHelper
      */
     public function getRaw()
     {
-        return $this->rawTitle;
+        return (string) $this->rawTitle;
     }
 
     /**

--- a/src/Helper/Title.php
+++ b/src/Helper/Title.php
@@ -19,12 +19,21 @@ class Title extends AbstractHelper
 {
     /**
      *
-     * The title value.
+     * The escaped title value (for HTML output).
      *
      * @var string
      *
      */
     protected $title = null;
+
+    /**
+     *
+     * The raw (unescaped) title value.
+     *
+     * @var string
+     *
+     */
+    protected $rawTitle = null;
 
     /**
      *
@@ -53,9 +62,32 @@ class Title extends AbstractHelper
      */
     public function __toString()
     {
-        $title = $this->indent(1, "<title>{$this->title}</title>");
-        $this->title = null;
-        return $title;
+        return $this->indent(1, "<title>{$this->title}</title>");
+    }
+
+    /**
+     *
+     * Returns the escaped title string for use in HTML contexts.
+     *
+     * @return string The escaped title string.
+     *
+     */
+    public function get()
+    {
+        return $this->title;
+    }
+
+    /**
+     *
+     * Returns the raw (unescaped) title string for use in non-HTML contexts
+     * such as og:title meta tags or JavaScript.
+     *
+     * @return string The raw title string.
+     *
+     */
+    public function getRaw()
+    {
+        return $this->rawTitle;
     }
 
     /**
@@ -70,6 +102,7 @@ class Title extends AbstractHelper
     public function set($text)
     {
         $this->title = $this->escaper->html($text);
+        $this->rawTitle = $text;
         return $this;
     }
 
@@ -85,6 +118,7 @@ class Title extends AbstractHelper
     public function setRaw($text)
     {
         $this->title = $text;
+        $this->rawTitle = $text;
         return $this;
     }
 
@@ -100,6 +134,7 @@ class Title extends AbstractHelper
     public function append($text)
     {
         $this->title .= $this->escaper->html($text);
+        $this->rawTitle .= $text;
         return $this;
     }
 
@@ -115,6 +150,7 @@ class Title extends AbstractHelper
     public function appendRaw($text)
     {
         $this->title .= $text;
+        $this->rawTitle .= $text;
         return $this;
     }
 
@@ -130,6 +166,7 @@ class Title extends AbstractHelper
     public function prepend($text)
     {
         $this->title = $this->escaper->html($text) . $this->title;
+        $this->rawTitle = $text . $this->rawTitle;
         return $this;
     }
 
@@ -145,6 +182,7 @@ class Title extends AbstractHelper
     public function prependRaw($text)
     {
         $this->title = $text . $this->title;
+        $this->rawTitle = $text . $this->rawTitle;
         return $this;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read back the title in both escaped (HTML-safe) and raw (unescaped) forms for use in meta tags and layouts.

* **Bug Fixes**
  * Title helper no longer resets its state after rendering; subsequent reads and mutations work as expected.

* **Documentation**
  * Updated helper docs with examples and guidance on escaped vs raw behavior; added PHPDoc improvements for better editor autocomplete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auraphp/Aura.Html/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->